### PR TITLE
Expand ruby filetypes

### DIFF
--- a/lib/lint_trap/es_linter.rb
+++ b/lib/lint_trap/es_linter.rb
@@ -3,16 +3,20 @@ require 'lint_trap/linter'
 module LintTrap
   # ES/JS Linter
   class EsLinter < Linter
-    def initialize(files, options)
-      @type = :es
-      @spec = {
-        color: :red,
-        command: 'eslint -f json',
-        filter: ->(file) { File.extname(file) == '.js' }
-      }
-      @pwd = `printf $(pwd)`
+    def type
+      :es
+    end
 
-      super(files, options)
+    def color
+      :red
+    end
+
+    def command
+      'eslint -f json'
+    end
+
+    def filter(file)
+      File.extname(file) == '.js'
     end
 
     private
@@ -21,10 +25,14 @@ module LintTrap
       [
         file['filePath'],
         file['messages'].map do |message|
-          next unless @files[file['filePath'].sub("#{@pwd}/", '')].include?(message['line'])
+          next unless @files[file['filePath'].sub("#{pwd}/", '')].include?(message['line'])
           standardize(message, 'column', 'line', 'ruleId', 'message', 'severity', 2)
         end.reject(&:nil?)
       ]
+    end
+
+    def pwd
+      @pwd ||= `printf $(pwd)`
     end
   end
 end

--- a/lib/lint_trap/es_linter.rb
+++ b/lib/lint_trap/es_linter.rb
@@ -8,7 +8,7 @@ module LintTrap
       @spec = {
         color: :red,
         command: 'eslint -f json',
-        extension: '.js'
+        filter: ->(file) { File.extname(file) == '.js' }
       }
       @pwd = `printf $(pwd)`
 

--- a/lib/lint_trap/haml_linter.rb
+++ b/lib/lint_trap/haml_linter.rb
@@ -8,7 +8,7 @@ module LintTrap
       @spec = {
         color: :magenta,
         command: 'haml-lint -r json',
-        extension: '.haml'
+        filter: ->(file) { File.extname(file) == '.haml' }
       }
       super(files, options)
     end

--- a/lib/lint_trap/haml_linter.rb
+++ b/lib/lint_trap/haml_linter.rb
@@ -3,14 +3,20 @@ require 'lint_trap/ruby_base_linter'
 module LintTrap
   # HAML Linter
   class HamlLinter < RubyBaseLinter
-    def initialize(files, options)
-      @type = :haml
-      @spec = {
-        color: :magenta,
-        command: 'haml-lint -r json',
-        filter: ->(file) { File.extname(file) == '.haml' }
-      }
-      super(files, options)
+    def type
+      :haml
+    end
+
+    def color
+      :magenta
+    end
+
+    def command
+      'haml-lint -r json'
+    end
+
+    def filter(file)
+      File.extname(file) == '.haml'
     end
   end
 end

--- a/lib/lint_trap/linter.rb
+++ b/lib/lint_trap/linter.rb
@@ -3,7 +3,7 @@ module LintTrap
   class Linter
     def initialize(files, options)
       @options = options
-      @files = Hash[files.select { |file, _lines| @spec[:filter].call(file) }]
+      @files = Hash[files.select { |file, _lines| filter(file) }]
       @messages = {} if @files.empty?
       relevant_messages
     end
@@ -21,7 +21,7 @@ module LintTrap
     end
 
     def format_error(filename, message)
-      filename.colorize(color: @spec[:color]) + ':' +
+      filename.colorize(color: color) + ':' +
         format_line(message) + ' ' +
         format_severity(message) + ' ' +
         message[:message] +
@@ -55,7 +55,7 @@ module LintTrap
     end
 
     def relevant_messages
-      @messages ||= errors(JSON.parse(`git diff --name-only --diff-filter=ACMRTUXB #{@options[:branch]} #{@files.map(&:first).join(' ')} | xargs #{@spec[:command]}`))
+      @messages ||= errors(JSON.parse(`git diff --name-only --diff-filter=ACMRTUXB #{@options[:branch]} #{@files.map(&:first).join(' ')} | xargs #{command}`))
     rescue => e
       if @options[:stdout]
         puts "#{'ERROR'.colorize(:red)}: #{e}"
@@ -67,9 +67,9 @@ module LintTrap
     end
 
     def pretty_print
-      puts "#{left_bump}Linting #{@type.to_s.colorize(@spec[:color])}…".colorize(mode: :bold)
+      puts "#{left_bump}Linting #{@type.to_s.colorize(color)}…".colorize(mode: :bold)
       format_errors || puts("#{left_bump(2)}#{"#{@type.to_s.upcase} all clear! ✔".colorize(color: :light_green)}")
-      puts "#{left_bump}Done linting #{@type.to_s.colorize(@spec[:color])}\n".colorize(mode: :bold) if @options[:verbose]
+      puts "#{left_bump}Done linting #{@type.to_s.colorize(color)}\n".colorize(mode: :bold) if @options[:verbose]
     end
 
     private
@@ -103,7 +103,7 @@ module LintTrap
     end
 
     def left_bump(indent = 1)
-      '▎'.ljust(indent * 2).colorize(color: @spec[:color])
+      '▎'.ljust(indent * 2).colorize(color: color)
     end
 
     def map_errors(errors)

--- a/lib/lint_trap/processor.rb
+++ b/lib/lint_trap/processor.rb
@@ -34,7 +34,7 @@ module LintTrap
     def extract_line_sets(diffs)
       diffs.map do |lines|
         nums = lines.match(/^.+\+(?<from>[0-9]+)(,(?<len>[0-9]+))? .+$/)
-        Range.new(nums[:from].to_i, nums[:from].to_i + nums[:len])
+        Range.new(nums[:from].to_i, nums[:from].to_i + nums[:len].to_i)
       end.map(&:to_a).flatten
     end
 

--- a/lib/lint_trap/ruby_linter.rb
+++ b/lib/lint_trap/ruby_linter.rb
@@ -5,10 +5,11 @@ module LintTrap
   class RubyLinter < RubyBaseLinter
     def initialize(files, options)
       @type = :ruby
+      @eligible_files = `rubocop -L`.split("\n")
       @spec = {
         color: :yellow,
         command: 'rubocop -f json',
-        extension: '.rb'
+        filter: ->(file) { @eligible_files.include?(file) }
       }
       super(files, options)
     end

--- a/lib/lint_trap/ruby_linter.rb
+++ b/lib/lint_trap/ruby_linter.rb
@@ -3,15 +3,24 @@ require 'lint_trap/ruby_base_linter'
 module LintTrap
   # Ruby Linter
   class RubyLinter < RubyBaseLinter
-    def initialize(files, options)
-      @type = :ruby
-      @eligible_files = `rubocop -L`.split("\n")
-      @spec = {
-        color: :yellow,
-        command: 'rubocop -f json',
-        filter: ->(file) { @eligible_files.include?(file) }
-      }
-      super(files, options)
+    def type
+      :ruby
+    end
+
+    def color
+      :yellow
+    end
+
+    def command
+      'rubocop -f json'
+    end
+
+    def filter(file)
+      eligible_files.include?(file)
+    end
+
+    def eligible_files
+      @eligible_files ||= `rubocop -L`.split("\n")
     end
   end
 end

--- a/lib/lint_trap/scss_linter.rb
+++ b/lib/lint_trap/scss_linter.rb
@@ -3,14 +3,20 @@ require 'lint_trap/linter'
 module LintTrap
   # SASS Linter
   class ScssLinter < Linter
-    def initialize(files, options)
-      @type = :scss
-      @spec = {
-        color: :blue,
-        command: 'scss-lint -f JSON',
-        filter: ->(file) { File.extname(file) == '.scss' }
-      }
-      super(files, options)
+    def type
+      :scss
+    end
+
+    def color
+      :blue
+    end
+
+    def command
+      'scss-lint -f JSON'
+    end
+
+    def filter(file)
+      File.extname(file) == '.scss'
     end
 
     private

--- a/lib/lint_trap/scss_linter.rb
+++ b/lib/lint_trap/scss_linter.rb
@@ -8,7 +8,7 @@ module LintTrap
       @spec = {
         color: :blue,
         command: 'scss-lint -f JSON',
-        extension: '.scss'
+        filter: ->(file) { File.extname(file) == '.scss' }
       }
       super(files, options)
     end


### PR DESCRIPTION
Resolves #2 .

Also removes the awkward `@spec` pattern of storing attributes in favor of more traditional methods. It may be worth storing these values as instance vars (as suggested at the [Ruby Style Guides](https://github.com/bbatsov/ruby-style-guide/issues/328))? But that's a thought for another time, I think.
