### PR TITLE
#9 Allow the user to specify paths to lint

### DIFF
--- a/bin/gnurr
+++ b/bin/gnurr
@@ -10,7 +10,7 @@ options = {
 }
 
 option_parser = OptionParser.new do |opts|
-  opts.banner = 'Usage: gnurr [options]'
+  opts.banner = 'Usage: gnurr [options] [--] [<path>...]'
 
   opts.on('-b', '--base NAME',
           'Base reference: branch, SHA, etc for diff (default: master)') do |v|
@@ -45,6 +45,9 @@ end
 
 begin
   option_parser.parse!
+  if !ARGV.nil? && ARGV.any?
+    options[:path] = ARGV
+  end
 rescue OptionParser::InvalidOption => error
   puts "Gnurr doesn't recognize that #{error}"
   exit

--- a/lib/gnurr/cli.rb
+++ b/lib/gnurr/cli.rb
@@ -78,7 +78,7 @@ module Gnurr
 
     def format_no_changes(diffs)
       if diffs.empty?
-        puts "#{left_bump(2)}No changes.".colorize(mode: :bold)
+        puts "#{left_bump(2)}No changes#{' at specified paths' unless @options[:path].nil?}.".colorize(mode: :bold)
         true
       end
     end

--- a/lib/gnurr/git.rb
+++ b/lib/gnurr/git.rb
@@ -16,7 +16,8 @@ module Gnurr
 
     def full_file_diff
       return @diff if @diff
-      diff = `git diff #{@options[:base]} --name-only --diff-filter=ACMRTUXB`
+      path = @options[:path].nil? || !@options[:path].any? ? '' : "-- #{@options[:path].join(' ')}"
+      diff = `git diff #{@options[:base]} --name-only --diff-filter=ACMRTUXB #{path}`
                .split("\n")
                .map { |file| [file, file_diffs(file)] }
       @diff = Hash[diff.select { |_k, v| v && v.any? }]

--- a/lib/gnurr/linter.rb
+++ b/lib/gnurr/linter.rb
@@ -16,7 +16,8 @@ module Gnurr
         base: 'master',
         expanded: false,
         stdout: false,
-        verbose: false
+        verbose: false,
+        path: nil
       }.merge(options)
       raise "Dependency not available for #{type}" unless requirements_met?
     rescue => e

--- a/lib/gnurr/linters/es_linter.rb
+++ b/lib/gnurr/linters/es_linter.rb
@@ -31,7 +31,7 @@ module Gnurr
       end
 
       def relative_filename(filename)
-        filename.sub(%r{^#{pwd}/}, '')
+        filename.sub(%r{^#{pwd}/}i, '')
       end
 
       def requirements_met?

--- a/lib/gnurr/version.rb
+++ b/lib/gnurr/version.rb
@@ -1,3 +1,3 @@
 module Gnurr
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.4.0'.freeze
 end


### PR DESCRIPTION
Also fixes small issue with Linter::ESLint's `relative_filename` method.