### PR TITLE
Update ruby version dependency

### DIFF
--- a/gnurr.gemspec
+++ b/gnurr.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
     'rubocop for Ruby linting'
   ]
 
-  spec.required_ruby_version = '~> 2.3.0'
+  spec.required_ruby_version = '~> 2.3'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Make it so `gnurr` is flexible with our ever-changing Lynx codebases... up until Ruby v3.0 +